### PR TITLE
Fix indentation error in SimpleStrategy

### DIFF
--- a/strategies.py
+++ b/strategies.py
@@ -498,27 +498,28 @@ class SimpleStrategy(BaseStrategy):
         if self.last_buy_zone == zone and zone != 'D':
             return
 
-   # Additional check for zone C bounce
-if zone == 'C':
-    period = self.params.atr_period
-    lookback = min(period, len(self))
-    lows = [self.data.low[-i] for i in range(lookback)]
-    min_low = min(lows)
-    bounce = (price - min_low) / min_low * 100
-    if bounce < 0.5:
-        return
+        # Additional check for zone C bounce
+        if zone == 'C':
+            period = self.params.atr_period
+            lookback = min(period, len(self))
+            lows = [self.data.low[-i] for i in range(lookback)]
+            min_low = min(lows)
+            bounce = (price - min_low) / min_low * 100
+            if bounce < 0.5:
+                return
 
-if zone != 'D':
-    trade_value = self._pick_chunk_size(zone)
-    if trade_value > 0:
-        size = trade_value / price
-        self.log_buy_signal(price, f'Zone {zone} entry')
-        self.log(
-            f'BUY CREATE: Zone {zone} Price: {price:.2f}, Value: {trade_value:.2f}'
-        )
-        self.order = self.buy(size=size)
-        self.lots.append({'entry': price, 'size': size})
-        self.allocated += trade_value
+        if zone != 'D':
+            trade_value = self._pick_chunk_size(zone)
+            if trade_value > 0:
+                size = trade_value / price
+                self.log_buy_signal(price, f'Zone {zone} entry')
+                self.log(
+                    f'BUY CREATE: Zone {zone} Price: {price:.2f}, Value: {trade_value:.2f}'
+                )
+                self.order = self.buy(size=size)
+                self.lots.append({'entry': price, 'size': size})
+                self.allocated += trade_value
+
 
         self.last_buy_time = dt
         self.last_buy_zone = zone


### PR DESCRIPTION
## Summary
- fix mis-indented zone check logic in `strategies.py`

## Testing
- `python -m py_compile strategies.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f8f352b10832783fa886a8c8008db