### PR TITLE
Add batch backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Run backtests from the command line:
 ```bash
 python main.py
 ```
+You can provide multiple symbols when prompted. Separate them with commas to run
+batch backtests:
+```bash
+# Example input when prompted for symbols
+BTC-USD, ETH-USD, AAPL
+```
 
 ## Creating Custom Strategies
 

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -172,7 +172,7 @@ class DataFetcher:
     def get_user_config() -> Optional[Dict]:
         """Get user configuration - can be replaced with UI input"""
         default_start, default_end = DataFetcher.get_default_dates()
-        
+
         # Default configuration
         default_config = {
             'symbol': 'BTC-USD',
@@ -182,7 +182,12 @@ class DataFetcher:
             'initial_capital': 10000,
             'commission': 0.001
         }
-        
+
+        user_input = input("Enter trading symbol(s) (comma separated) [BTC-USD]: ").strip()
+        if user_input:
+            symbols = [s.strip() for s in user_input.split(',') if s.strip()]
+            default_config['symbol'] = symbols if len(symbols) > 1 else symbols[0]
+
         return default_config
     
     @staticmethod


### PR DESCRIPTION
## Summary
- support batch backtesting in main CLI
- parse comma-separated symbols in `DataFetcher.get_user_config`
- accept multiple symbols in the Streamlit UI
- show batch results in the UI when run
- document batch usage in README

## Testing
- `python -m py_compile main.py data_fetcher.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875424704cc8327968a0c7fedd1f336